### PR TITLE
Readme k3s

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
 # github_rep
-azure repository web site L4
+curl -sfL https://get.k3s.io | sh -s - --disable traefik --write-kubeconfig-mode 644 --node-name k3s-master-01
+
+Rancher's k3s - Primeros pasos
+Distribución de Kubernetes liviana, fácil y rápida con una huella muy pequeña
+https://k3s.io o https://k3d.io para la versión dockerizada de k3s.
+
+Manifestación
+Usaré Linode para esa demostración.
+
+Instalar maestro
+curl -sfL https://get.k3s.io | sh -s - --disable traefik --write-kubeconfig-mode 644 --node-name k3s-master-01
+
+Instalar trabajador
+Tome el token del nodo maestro para poder agregarle nodos trabajados:
+cat /var/lib/rancher/k3s/server/node-token
+Instale k3s en el nodo trabajador y agréguelo a nuestro clúster:
+curl -sfL https://get.k3s.io | K3S_NODE_NAME=k3s-worker-01 K3S_URL=https://<IP>:6443 K3S_TOKEN=<TOKEN> sh - 
+
+Instalar el controlador de entrada nginx
+Sitio web: https://kubernetes.github.io/ingress-nginx/
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.2.1/deploy/static/provider/cloud/deploy.yaml
+
+Nota importante para AWS, Azure, GCP
+No puedo explicarlo en detalle, pero si ejecuta una máquina virtual en AWS, Azure o GCP, el "ingreso-nginx" solo seleccionará la IP privada como IP externa. Debe editar manualmente el servicio para que su dirección IP pública esté disponible para nginx, de modo que pueda comenzar a escuchar en su dirección IP pública.
+kubectl -n ingress-nginx edit svc ingress-nginx-controller
+Agregue su IP como lista para que spec.externalIPsle guste:
+
+  spec:
+    externalIPs:
+    - <YOUR_IP>
+
+
+
+Información adicional
+Puede cambiar la configuración de k3s cambiando la configuración del servicio, por ejemplo, con nano /etc/systemd/system/k3s.service.
+Asegúrese de reiniciar el servicio después:systemctl restart k3s
+En muchos casos, puede volver a ejecutar el instalador con diferentes variables y configurará su clúster en consecuencia sin eliminarlo en primer lugar.
+
+Implementar aplicación de demostración
+kubectl apply -f manifest.yaml


### PR DESCRIPTION
# Rancher's k3s - Primeros pasos

Distribución de Kubernetes liviana, fácil y rápida con una huella muy pequeña

https://k3s.io o https://k3d.io para la versión dockerizada de k3s.

##  Step 1: Update Ubuntu system ( server y worker)
With your servers installed with Ubuntu 20.04, update and upgrade them:
sudo apt update
sudo apt -y upgrade && sudo systemctl reboot
.
sudo ufw allow 6443/tcp
sudo ufw allow 443/tcp

## Add your user to Docker group to avoid typing sudo everytime you run docker commands.
sudo usermod -aG docker ${USER}
newgrp docker

### Instalar maestro

`curl -sfL https://get.k3s.io | sh -s - --disable traefik --write-kubeconfig-mode 644 --node-name k3s-master-01`

### Instalar Worker

Tome el token del nodo maestro para poder agregarle nodos trabajados:

`cat /var/lib/rancher/k3s/server/node-token`

Instale k3s en el nodo trabajador y agréguelo a nuestro clúster:

`curl -sfL https://get.k3s.io | K3S_NODE_NAME=k3s-worker-01 K3S_URL=https://<IP>:6443 K3S_TOKEN=<TOKEN> sh -`

curl -sfL https://get.k3s.io | K3S_NODE_NAME=k3s-worker-01 K3S_URL=https://10.128.0.9:6443 K3S_TOKEN=K1097cbffbb0f65d3a8c645a73bfc7570ec7a4f9c38eb14fedba3685a11469fd0fe::server:4bc573eb869c0da574284f8ce13399d2 sh -
el del master

curl -sfL https://get.k3s.io | K3S_NODE_NAME=k3s-worker-01 K3S_URL=https://10.128.0.4:6443 K3S_TOKEN=K10ce2b02969fbb57f1d5b5907a3c716560b2783d918078ddcde86dda4264f73e92::server:360517b6eb2f7c876834318a565800e9 sh -

##You can verify if the k3s-agent on the worker nodes is running by:
sudo systemctl status k3s-agent

## validar la conexión 
kubectl get nodes


### Instalar el controlador de entrada nginx

Sitio web: https://kubernetes.github.io/ingress-nginx/

`kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.2.1/deploy/static/provider/cloud/deploy.yaml`

#### Nota importante para AWS, Azure, GCP

No puedo explicarlo en detalle, pero si ejecuta una máquina virtual en AWS, Azure o GCP, el "ingreso-nginx" solo seleccionará la IP privada como IP externa. Debe editar manualmente el servicio para que su dirección IP pública esté disponible para nginx, de modo que pueda comenzar a escuchar en su dirección IP pública.

`kubectl -n ingress-nginx edit svc ingress-nginx-controller`

Agregue su IP como lista para que `spec.externalIPs`le guste:

```
  spec:
    externalIPs:
    - <YOUR_IP>
```
## validar la conexión 
kubectl get ing

### Información adicional

Puede cambiar la configuración de k3s cambiando la configuración del servicio, por ejemplo, con `nano /etc/systemd/system/k3s.service`.

Asegúrese de reiniciar el servicio después:`systemctl restart k3s`

En muchos casos, puede volver a ejecutar el instalador con diferentes variables y configurará su clúster en consecuencia sin eliminarlo en primer lugar.

### Implementar aplicación de demostración

`kubectl apply -f manifest.yaml`Rancher's k3s - Primeros pasos
Distribución de Kubernetes liviana, fácil y rápida con una huella muy pequeña
https://k3s.io/ o https://k3d.io/ para la versión dockerizada de k3s.

Manifestación
Usaré Linode para esa demostración.

Instalar maestro
curl -sfL https://get.k3s.io | sh -s - --disable traefik --write-kubeconfig-mode 644 --node-name k3s-master-01

Instalar trabajador
Tome el token del nodo maestro para poder agregarle nodos trabajados:
cat /var/lib/rancher/k3s/server/node-token
K10ce2b02969fbb57f1d5b5907a3c716560b2783d918078ddcde86dda4264f73e92::server:360517b6eb2f7c876834318a565800e9


Instale k3s en el nodo trabajador y agréguelo a nuestro clúster:
curl -sfL https://get.k3s.io | K3S_NODE_NAME=k3s-worker-01 K3S_URL=https://<IP>:6443 K3S_TOKEN=<TOKEN> sh - 

## Instalar el controlador de entrada nginx
Sitio web: https://kubernetes.github.io/ingress-nginx/
kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.2.1/deploy/static/provider/cloud/deploy.yaml

## validar conexion
kubectl -n ingress-nginx get po
kubectl -n ingress-nginx get svc

Nota importante para AWS, Azure, GCP
No puedo explicarlo en detalle, pero si ejecuta una máquina virtual en AWS, Azure o GCP, el "ingreso-nginx" solo seleccionará la IP privada como IP externa. Debe editar manualmente el servicio para que su dirección IP pública esté disponible para nginx, de modo que pueda comenzar a escuchar en su dirección IP pública.
kubectl -n ingress-nginx edit svc ingress-nginx-controller
Agregue su IP como lista para que spec.externalIPsle guste:

  spec:
    externalIPs:
    - <YOUR_IP>



Información adicional
Puede cambiar la configuración de k3s cambiando la configuración del servicio, por ejemplo, con nano /etc/systemd/system/k3s.service.
Asegúrese de reiniciar el servicio después:systemctl restart k3s
En muchos casos, puede volver a ejecutar el instalador con diferentes variables y configurará su clúster en consecuencia sin eliminarlo en primer lugar.

Implementar aplicación de demostración
kubectl apply -f manifest.yaml